### PR TITLE
Adds support for reading pins from older IPFS versions <0.5

### DIFF
--- a/cmd/ipfs-copy/ipfs_version.go
+++ b/cmd/ipfs-copy/ipfs_version.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/coreos/go-semver/semver"
+
+func hasShellStreamPinListSupport(version string) bool {
+	sourceShellVersion := semver.New(version)
+	// The `pin ls --stream` feature was added in https://github.com/ipfs/go-ipfs/blob/master/CHANGELOG.md#050-2020-04-28
+	requiredEnumStreamVersion := semver.New("0.5.0")
+
+	return requiredEnumStreamVersion.LessThan(*sourceShellVersion) || requiredEnumStreamVersion.Equal(*sourceShellVersion)
+}

--- a/cmd/ipfs-copy/ipfs_version_test.go
+++ b/cmd/ipfs-copy/ipfs_version_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasShellStreamListSupport(t *testing.T) {
+	require.False(t, hasShellStreamPinListSupport("0.4.22"))
+	require.True(t, hasShellStreamPinListSupport("0.5.0"))
+	require.True(t, hasShellStreamPinListSupport("0.5.1"))
+	require.True(t, hasShellStreamPinListSupport("0.7.0"))
+	require.True(t, hasShellStreamPinListSupport("0.9.1"))
+}

--- a/copy.go
+++ b/copy.go
@@ -44,7 +44,7 @@ func PinCIDsFromSource(ctx context.Context, workers int, hasSourceShellListStrea
 
 	if hasSourceShellListStreaming {
 		log.Printf("[INFO] Streaming pins from the source IPFS node...")
-		err = streamPinsFromSource(pins, sourceShell)
+		err = streamPinsFromSource(ctx, pins, sourceShell)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -61,8 +61,8 @@ func PinCIDsFromSource(ctx context.Context, workers int, hasSourceShellListStrea
 	return successPinsCount, failedPinsCount, nil
 }
 
-func streamPinsFromSource(cids chan ipfsCid.Cid, sourceShell *ipfsShell.Shell) error {
-	pinStream, err := sourceShell.PinsStream(context.Background())
+func streamPinsFromSource(ctx context.Context, cids chan ipfsCid.Cid, sourceShell *ipfsShell.Shell) error {
+	pinStream, err := sourceShell.PinsStream(ctx)
 	if err != nil {
 		return err
 	}

--- a/copy.go
+++ b/copy.go
@@ -37,30 +37,45 @@ func PinCIDsFromFile(ctx context.Context, file io.ReadSeeker, workers int, infur
 }
 
 // PinCIDsFromSource iterates over all pins, filters Recursive + Direct, and pins then in parallel with multiple workers via the pre-configured shell.
-func PinCIDsFromSource(ctx context.Context, sourceApiUrl string, workers int, infuraShell *ipfsShell.Shell, failedPinsWriter ipfsPump.FailedBlocksWriter) (successPinsCount uint64, skippedIndirectPinsCount uint64, failedPinsCount uint64, err error) {
-	cids := make(chan ipfsCid.Cid)
+func PinCIDsFromSource(ctx context.Context, workers int, hasSourceShellListStreaming bool, sourceShell *ipfsShell.Shell, infuraShell *ipfsShell.Shell, failedPinsWriter ipfsPump.FailedBlocksWriter) (successPinsCount uint64, failedPinsCount uint64, err error) {
+	pins := make(chan ipfsCid.Cid)
 	successPinsCount = 0
 	failedPinsCount = 0
-	skippedIndirectPinsCount = 0
 
-	sourceShell := ipfsShell.NewShell(sourceApiUrl)
-	pinStream, err := sourceShell.PinsStream(context.Background())
-	if err != nil {
-		return 0, 0, 0, err
+	if hasSourceShellListStreaming {
+		log.Printf("[INFO] Streaming pins from the source IPFS node...")
+		err = streamPinsFromSource(pins, sourceShell)
+		if err != nil {
+			return 0, 0, err
+		}
+	} else {
+		log.Printf("[INFO] Fetching pins from the source IPFS node to memory...")
+		err = fetchPinsFromSource(pins, sourceShell)
+		if err != nil {
+			return 0, 0, err
+		}
 	}
 
-	// Read all the pins from the source shell
+	successPinsCount, failedPinsCount = pinCIDs(pins, workers, infuraShell, failedPinsWriter)
+
+	return successPinsCount, failedPinsCount, nil
+}
+
+func streamPinsFromSource(cids chan ipfsCid.Cid, sourceShell *ipfsShell.Shell) error {
+	pinStream, err := sourceShell.PinsStream(context.Background())
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		for pinInfo := range pinStream {
 			if pinInfo.Type == ipfsShell.IndirectPin {
-				//log.Printf("[DEBUG] Skipping indirect pin from stream: '%v'\n", pinInfo.Cid)
-				skippedIndirectPinsCount++
 				continue
 			}
 
 			c, err := ipfsCid.Parse(pinInfo.Cid)
 			if err != nil {
-				log.Printf("[ERROR] Failed parsing pin from stream. %v\n", err)
+				log.Printf("[ERROR] Failed parsing pin '%v' from stream. %v\n", pinInfo.Cid, err)
 				continue
 			}
 
@@ -69,9 +84,43 @@ func PinCIDsFromSource(ctx context.Context, sourceApiUrl string, workers int, in
 		close(cids)
 	}()
 
-	successPinsCount, failedPinsCount = pinCIDs(cids, workers, infuraShell, failedPinsWriter)
+	return nil
+}
 
-	return successPinsCount, skippedIndirectPinsCount, failedPinsCount, nil
+// fetchPinsFromSource is a duplicate of streamPinsFromSource but without the streaming logic.
+//
+// The difference is:
+// - IPFS version < 0.5.0 has no stream support
+// - The Pins() loads all the pins from source into memory at once
+// - The code can't be reused much or wrapped or decorated because the Shell returns quite different responses:
+//     - PinsStream() returns <-chan **PinStreamInfo**
+//     - Pins() returns map[string]**PinInfo**
+//
+// Hence it's easier to duplicate than create awkward abstractions in this case.
+func fetchPinsFromSource(cids chan ipfsCid.Cid, sourceShell *ipfsShell.Shell) error {
+	pins, err := sourceShell.Pins()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for cid, info := range pins {
+			if info.Type == ipfsShell.IndirectPin {
+				continue
+			}
+
+			c, err := ipfsCid.Parse(cid)
+			if err != nil {
+				log.Printf("[ERROR] Failed parsing pin '%v' from stream. %v\n", cid, err)
+				continue
+			}
+
+			cids <- c
+		}
+		close(cids)
+	}()
+
+	return nil
 }
 
 func pinCIDs(cids <-chan ipfsCid.Cid, workers int, infuraShell *ipfsShell.Shell, failedPinsWriter ipfsPump.FailedBlocksWriter) (successPinsCount uint64, failedPinsCount uint64) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/INFURA/ipfs-pump v1.2.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
+	github.com/coreos/go-semver v0.3.0
 	github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23
 	github.com/gravitational/log v0.0.0-20200127200505-fdffa14162b0 // indirect
 	github.com/gravitational/trace v1.1.14 // indirect
@@ -13,6 +14,7 @@ require (
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyV
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 h1:HVTnpeuvF6Owjd5mniCL8DEXo7uYXdQEmOP4FJbV5tg=
 github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3/go.mod h1:p1d6YEZWvFzEh4KLyvBcVSnrfNDDvK2zfK/4x2v/4pE=


### PR DESCRIPTION
Fix for https://github.com/INFURA/ipfs-copy/issues/4

Tested locally with user's IPFS 0.4.22 as well as latest IPFS 0.9